### PR TITLE
HIVE-21409 Add Jars to Session Conf ClassLoader

### DIFF
--- a/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
+++ b/ql/src/java/org/apache/hadoop/hive/ql/session/SessionState.java
@@ -1366,7 +1366,7 @@ public class SessionState {
   static void registerJars(List<String> newJars) throws IllegalArgumentException {
     LogHelper console = getConsole();
     try {
-      ClassLoader loader = Thread.currentThread().getContextClassLoader();
+      ClassLoader loader = SessionState.get().getConf().getClassLoader();
       ClassLoader newLoader = Utilities.addToClassPath(loader, newJars.toArray(new String[0]));
       Thread.currentThread().setContextClassLoader(newLoader);
       SessionState.get().getConf().setClassLoader(newLoader);


### PR DESCRIPTION
It is possible that the current threads classloader may be modified after the sessionstate hiveconf has been attached to the current thread. This ensure we are always adding jars to the correct class loader.